### PR TITLE
Step 1.2. Boxing and pinning

### DIFF
--- a/1_concepts/1_2_box_pin/src/main.rs
+++ b/1_concepts/1_2_box_pin/src/main.rs
@@ -1,4 +1,5 @@
 mod task_1;
+mod task_2;
 
 fn main() {
     task_1::run();

--- a/1_concepts/1_2_box_pin/src/main.rs
+++ b/1_concepts/1_2_box_pin/src/main.rs
@@ -1,3 +1,5 @@
+mod task_1;
+
 fn main() {
-    println!("Implement me!");
+    task_1::run();
 }

--- a/1_concepts/1_2_box_pin/src/task_1.rs
+++ b/1_concepts/1_2_box_pin/src/task_1.rs
@@ -1,0 +1,106 @@
+use core::fmt;
+use std::collections::LinkedList;
+use std::pin::{pin, Pin};
+use std::rc::Rc;
+
+trait SayHi: fmt::Debug {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Hi from {self:?}")
+    }
+}
+
+impl<T: fmt::Debug> SayHi for T {}
+
+mod mut_non_t {
+    use std::pin::Pin;
+    use std::rc::Rc;
+
+    pub(super) trait MutMeSomehow {
+        fn mut_me_somehow(self: Pin<&mut Self>);
+    }
+
+    impl<T: Default> MutMeSomehow for Box<T> {
+        fn mut_me_somehow(mut self: Pin<&mut Self>) {
+            *self.as_mut() = Box::default();
+        }
+    }
+
+    impl<T: Default> MutMeSomehow for Rc<T> {
+        fn mut_me_somehow(self: Pin<&mut Self>) {
+            if let Some(reference) = Rc::get_mut(self.get_mut()) {
+                *reference = Default::default();
+            }
+        }
+    }
+
+    impl<T> MutMeSomehow for Vec<T> {
+        fn mut_me_somehow(self: Pin<&mut Self>) {
+            unsafe {
+                // SAFETY: the `Vec` is not moved, only the data it points to is modified.
+                self.get_unchecked_mut().reverse();
+            }
+        }
+    }
+
+    impl MutMeSomehow for String {
+        fn mut_me_somehow(mut self: Pin<&mut Self>) {
+            self.push_str("hello world");
+        }
+    }
+
+    impl MutMeSomehow for &[u8] {
+        fn mut_me_somehow(mut self: Pin<&mut Self>) {
+            *self = b"hello world";
+        }
+    }
+}
+
+mod mut_t {
+    use std::pin::Pin;
+
+    pub(super) trait MutMeSomehow {
+        fn mut_me_somehow(self: Pin<&mut Self>);
+    }
+
+    impl<T: Default> MutMeSomehow for T {
+        fn mut_me_somehow(self: Pin<&mut Self>) {
+            unsafe {
+                // SAFETY: the previous value's destructor gets run before replacement,
+                // and T's Default::default() is a valid T.
+                *self.get_unchecked_mut() = Default::default();
+            }
+        }
+    }
+}
+
+pub(super) fn run() {
+    let mut pinned_box = pin!(Box::new(1));
+    let mut pinned_rc = pin!(Rc::new(2));
+    let mut pinned_vec = pin!(vec![3]);
+    let mut pinned_string = pin!(4.to_string());
+    let mut pinned_byte_slice = pin!([5].as_slice());
+    let mut pinned_t = pin!(LinkedList::from([6, 7, 8, 9]));
+
+    pinned_box.as_ref().say_hi();
+    pinned_rc.as_ref().say_hi();
+    pinned_vec.as_ref().say_hi();
+    pinned_string.as_ref().say_hi();
+    pinned_byte_slice.as_ref().say_hi();
+    pinned_t.as_ref().say_hi();
+
+    mut_non_t::MutMeSomehow::mut_me_somehow(pinned_box.as_mut());
+    mut_non_t::MutMeSomehow::mut_me_somehow(pinned_rc.as_mut());
+    mut_non_t::MutMeSomehow::mut_me_somehow(pinned_vec.as_mut());
+    mut_non_t::MutMeSomehow::mut_me_somehow(pinned_string.as_mut());
+    mut_non_t::MutMeSomehow::mut_me_somehow(pinned_byte_slice.as_mut());
+    mut_t::MutMeSomehow::mut_me_somehow(pinned_t.as_mut());
+
+    println!("=======");
+
+    pinned_box.as_ref().say_hi();
+    pinned_rc.as_ref().say_hi();
+    pinned_vec.as_ref().say_hi();
+    pinned_string.as_ref().say_hi();
+    pinned_byte_slice.as_ref().say_hi();
+    pinned_t.as_ref().say_hi();
+}

--- a/1_concepts/1_2_box_pin/src/task_2.rs
+++ b/1_concepts/1_2_box_pin/src/task_2.rs
@@ -1,0 +1,30 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+struct MeasurableFuture<Fut> {
+    inner_future: Fut,
+    started_at: Option<Instant>,
+}
+
+impl<Fut: Future> Future for MeasurableFuture<Fut> {
+    type Output = Fut::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let start_time = self.started_at;
+        let pinned_inner = unsafe {
+            // SAFETY: this is OK because `self.inner_future` is only accessed while pinned.
+            self.map_unchecked_mut(|s| &mut s.inner_future)
+        };
+
+        let poll = pinned_inner.poll(cx);
+        if matches!(poll, Poll::Ready(_)) {
+            if let Some(start_time) = start_time {
+                println!("took {} ns", (Instant::now() - start_time).as_nanos());
+            }
+        }
+
+        poll
+    }
+}

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ root (i.e. `cargo run -p step_1_8`). __Consider to use [rustfmt] and [Clippy] wh
 - [x] [0. Become familiar with Rust basics][Step 0] (3 days)
 - [ ] [1. Concepts][Step 1] (2 days, after all sub-steps)
     - [x] [1.1. Default values, cloning and copying][Step 1.1] (1 day)
-    - [ ] [1.2. Boxing and pinning][Step 1.2] (1 day)
+    - [x] [1.2. Boxing and pinning][Step 1.2] (1 day)
     - [ ] [1.3. Shared ownership and interior mutability][Step 1.3] (1 day)
     - [ ] [1.4. Clone-on-write][Step 1.4] (1 day)
     - [ ] [1.5. Conversions, casting and dereferencing][Step 1.5] (1 day)


### PR DESCRIPTION
Resolves [Step 1.2](https://github.com/Tassadaritze/rust-incubator/blob/main/1_concepts/1_2_box_pin)




## Task

1. Implement the traits `SayHi` and `MutMeSomehow` for the types `Box<T>`, `Rc<T>`, `Vec<T>`, `String`, `&[u8]`, and `T`.  

2. Implement `Future` for a `MeasurableFuture` struct that counts the execution time of an inner future.


## Solution

`SayHi`'s default implementation works for any `T` (as long as they implement `fmt::Debug`), so it was easy to just implement it for any `T: fmt::Debug`.

Since `MutMeSomehow`'s implementation for `T` would conflict with its implementations for the other types, I put it in a separate module. All its implementations try to do something with the concrete type if possible, falling back to replacing the pinned value with the default for its type (thus requiring an additional `Default` bound).

`MeasurableFuture` unsafely pins its inner future, polls it, and if it's ready, prints the time difference between `Instant::now()` and the start time (if one was provided).