### PR TITLE
Step 1.4: Clone-on-write

### DIFF
--- a/1_concepts/1_4_cow/src/main.rs
+++ b/1_concepts/1_4_cow/src/main.rs
@@ -1,3 +1,20 @@
+use std::borrow::Cow;
+use std::env;
+
 fn main() {
-    println!("Implement me!");
+    let mut path = Cow::Borrowed("/etc/app/app.conf");
+
+    let mut args = env::args();
+    if args.any(|arg| &arg == "--conf") {
+        path = args
+            .next()
+            .expect("the --conf argument should specify a path")
+            .into();
+    } else if let Ok(env_path) = env::var("APP_CONF") {
+        if !env_path.is_empty() {
+            path = env_path.into();
+        }
+    }
+
+    println!("{path}");
 }

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ root (i.e. `cargo run -p step_1_8`). __Consider to use [rustfmt] and [Clippy] wh
     - [x] [1.1. Default values, cloning and copying][Step 1.1] (1 day)
     - [x] [1.2. Boxing and pinning][Step 1.2] (1 day)
     - [x] [1.3. Shared ownership and interior mutability][Step 1.3] (1 day)
-    - [ ] [1.4. Clone-on-write][Step 1.4] (1 day)
+    - [x] [1.4. Clone-on-write][Step 1.4] (1 day)
     - [ ] [1.5. Conversions, casting and dereferencing][Step 1.5] (1 day)
     - [ ] [1.6. Static and dynamic dispatch][Step 1.6] (1 day)
     - [ ] [1.7. `Sized` and `?Sized` types][Step 1.7] (1 day)


### PR DESCRIPTION
Resolves [Step 1.4](https://github.com/Tassadaritze/rust-incubator/blob/main/1_concepts/1_4_cow)




## Task

Write a program that prints the path to its config.



## Solution

I used a `Cow<str>` that borrows a `&'static str` for the default. It gets replaced with an owning `Cow<str>` if a correct path is found either in the command line arguments or in the environment variables.