### PR TITLE
Step 1.6: Static and dynamic dispatch

### DIFF
--- a/1_concepts/1_6_dispatch/src/dynamic.rs
+++ b/1_concepts/1_6_dispatch/src/dynamic.rs
@@ -1,0 +1,48 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use crate::{Storage, User};
+
+struct UserRepository {
+    storage: Box<dyn Storage<u64, User>>,
+}
+
+impl UserRepository {
+    fn new(storage: impl Storage<u64, User> + 'static) -> Self {
+        Self {
+            storage: Box::new(storage),
+        }
+    }
+}
+
+impl Storage<u64, User> for UserRepository {
+    fn set(&mut self, key: u64, val: User) {
+        self.storage.set(key, val);
+    }
+
+    fn get(&self, key: &u64) -> Option<&User> {
+        self.storage.get(key)
+    }
+
+    fn remove(&mut self, key: &u64) -> Option<User> {
+        self.storage.remove(key)
+    }
+}
+
+pub(super) fn run() {
+    let mut repository = UserRepository::new(HashMap::new());
+    let user = User {
+        id: 0,
+        email: Default::default(),
+        activated: false,
+    };
+
+    repository.set(0, user);
+    assert_eq!(repository.get(&0).map(|u| u.id), Some(0));
+    assert_eq!(repository.get(&0).map(|u| &u.email), Some(&Cow::default()));
+    assert_eq!(repository.get(&0).map(|u| u.activated), Some(false));
+
+    assert_eq!(repository.remove(&0).map(|u| u.id), Some(0));
+    assert!(repository.remove(&0).is_none());
+    assert!(repository.get(&0).is_none());
+}

--- a/1_concepts/1_6_dispatch/src/main.rs
+++ b/1_concepts/1_6_dispatch/src/main.rs
@@ -1,4 +1,5 @@
 mod dynamic;
+mod static_;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -35,4 +36,5 @@ where
 
 fn main() {
     dynamic::run();
+    static_::run();
 }

--- a/1_concepts/1_6_dispatch/src/main.rs
+++ b/1_concepts/1_6_dispatch/src/main.rs
@@ -1,3 +1,38 @@
+mod dynamic;
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::hash::Hash;
+
+trait Storage<K, V> {
+    fn set(&mut self, key: K, val: V);
+    fn get(&self, key: &K) -> Option<&V>;
+    fn remove(&mut self, key: &K) -> Option<V>;
+}
+
+struct User {
+    id: u64,
+    email: Cow<'static, str>,
+    activated: bool,
+}
+
+impl<K, V> Storage<K, V> for HashMap<K, V>
+where
+    K: Eq + Hash,
+{
+    fn set(&mut self, key: K, val: V) {
+        self.insert(key, val);
+    }
+
+    fn get(&self, key: &K) -> Option<&V> {
+        self.get(key)
+    }
+
+    fn remove(&mut self, key: &K) -> Option<V> {
+        self.remove(key)
+    }
+}
+
 fn main() {
-    println!("Implement me!");
+    dynamic::run();
 }

--- a/1_concepts/1_6_dispatch/src/static_.rs
+++ b/1_concepts/1_6_dispatch/src/static_.rs
@@ -1,0 +1,46 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use crate::{Storage, User};
+
+struct UserRepository<S> {
+    storage: S,
+}
+
+impl<S: Storage<u64, User>> UserRepository<S> {
+    fn new(storage: S) -> Self {
+        Self { storage }
+    }
+}
+
+impl<S: Storage<u64, User>> Storage<u64, User> for UserRepository<S> {
+    fn set(&mut self, key: u64, val: User) {
+        self.storage.set(key, val);
+    }
+
+    fn get(&self, key: &u64) -> Option<&User> {
+        self.storage.get(key)
+    }
+
+    fn remove(&mut self, key: &u64) -> Option<User> {
+        self.storage.remove(key)
+    }
+}
+
+pub(super) fn run() {
+    let mut repository = UserRepository::new(HashMap::new());
+    let user = User {
+        id: 0,
+        email: Default::default(),
+        activated: false,
+    };
+
+    repository.set(0, user);
+    assert_eq!(repository.get(&0).map(|u| u.id), Some(0));
+    assert_eq!(repository.get(&0).map(|u| &u.email), Some(&Cow::default()));
+    assert_eq!(repository.get(&0).map(|u| u.activated), Some(false));
+
+    assert_eq!(repository.remove(&0).map(|u| u.id), Some(0));
+    assert!(repository.remove(&0).is_none());
+    assert!(repository.get(&0).is_none());
+}

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ root (i.e. `cargo run -p step_1_8`). __Consider to use [rustfmt] and [Clippy] wh
     - [x] [1.3. Shared ownership and interior mutability][Step 1.3] (1 day)
     - [x] [1.4. Clone-on-write][Step 1.4] (1 day)
     - [x] [1.5. Conversions, casting and dereferencing][Step 1.5] (1 day)
-    - [ ] [1.6. Static and dynamic dispatch][Step 1.6] (1 day)
+    - [x] [1.6. Static and dynamic dispatch][Step 1.6] (1 day)
     - [ ] [1.7. `Sized` and `?Sized` types][Step 1.7] (1 day)
     - [ ] [1.8. Thread safety][Step 1.8] (1 day)
     - [ ] [1.9. Phantom types][Step 1.9] (1 day)


### PR DESCRIPTION
Resolves [Step 1.6](https://github.com/Tassadaritze/rust-incubator/blob/main/1_concepts/1_6_dispatch)




## Task

Given the following `Storage` abstraction and `User` entity:
```rust
trait Storage<K, V> {
    fn set(&mut self, key: K, val: V);
    fn get(&self, key: &K) -> Option<&V>;
    fn remove(&mut self, key: &K) -> Option<V>;
}

struct User {
    id: u64,
    email: Cow<'static, str>,
    activated: bool,
}
```

Implement `UserRepository` type with injectable `Storage` implementation, which can get, add, update and remove `User` in the injected `Storage`. Make two different implementations: one should use [dynamic dispatch][2] for `Storage` injecting, and the other one should use [static dispatch][1].




## Solution

Created a `UserRepository` that wraps a `Box<dyn Storage<u64, User>>` and implements `Storage<u64, User>` itself, delegating trait method calls to its inner type via dynamic dispatch.

Created a `UserRepository<S>` that wraps the generic `S` and implements `Storage<u64, User>` itself, delegating trait method calls to its inner type via static dispatch.