### PR TITLE
Step 1.7: Sized and ?Sized types

### DIFF
--- a/1_concepts/1_7_sized/src/main.rs
+++ b/1_concepts/1_7_sized/src/main.rs
@@ -1,3 +1,159 @@
+use std::borrow::Cow;
+use std::cell::{Ref, RefCell};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug)]
+struct User {
+    id: u64,
+    email: Cow<'static, str>,
+    activated: bool,
+}
+
+trait UserRepository {
+    fn set(&self, key: u64, val: User);
+    fn get(&self, key: &u64) -> Option<Ref<User>>;
+    fn remove(&self, key: &u64) -> Option<User>;
+}
+
+struct InMemoryRepository {
+    storage: RefCell<HashMap<u64, User>>,
+}
+
+impl InMemoryRepository {
+    fn new() -> Self {
+        Self {
+            storage: RefCell::new(HashMap::new()),
+        }
+    }
+}
+
+impl UserRepository for InMemoryRepository {
+    fn set(&self, key: u64, val: User) {
+        self.storage.borrow_mut().insert(key, val);
+    }
+
+    fn get(&self, key: &u64) -> Option<Ref<User>> {
+        Ref::filter_map(self.storage.borrow(), |storage| storage.get(key)).ok()
+    }
+
+    fn remove(&self, key: &u64) -> Option<User> {
+        self.storage.borrow_mut().remove(key)
+    }
+}
+
+trait Command {}
+
+trait CommandHandler<C: Command> {
+    type Context: ?Sized;
+    type Result;
+
+    fn handle_command(&self, cmd: &C, ctx: &Self::Context) -> Self::Result;
+}
+
+struct CreateUser;
+impl Command for CreateUser {}
+
+type UserError = Box<dyn std::error::Error>;
+
+impl CommandHandler<CreateUser> for User {
+    type Context = dyn UserRepository;
+    type Result = Result<(), UserError>;
+
+    fn handle_command(&self, cmd: &CreateUser, user_repo: &Self::Context) -> Self::Result {
+        user_repo.set(
+            self.id,
+            User {
+                id: self.id,
+                email: self.email.clone(),
+                activated: self.activated,
+            },
+        );
+
+        Ok(())
+    }
+}
+
 fn main() {
-    println!("Implement me!");
+    let repository = InMemoryRepository::new();
+    let user = User {
+        id: 0,
+        email: Default::default(),
+        activated: false,
+    };
+
+    user.handle_command(&CreateUser, &repository).unwrap();
+
+    assert_eq!(repository.get(&0).map(|u| u.id), Some(0));
+    assert_eq!(repository.get(&0).unwrap().email, Cow::<'_, str>::default());
+    assert_eq!(repository.get(&0).map(|u| u.activated), Some(false));
+
+    assert_eq!(repository.remove(&0).map(|u| u.id), Some(0));
+    assert!(repository.remove(&0).is_none());
+    assert!(repository.get(&0).is_none());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockRepository {
+        value: RefCell<Option<User>>,
+    }
+
+    impl MockRepository {
+        fn new() -> Self {
+            Self {
+                value: RefCell::new(Some(User {
+                    id: 123,
+                    email: Cow::Borrowed("foo"),
+                    activated: true,
+                })),
+            }
+        }
+    }
+
+    impl UserRepository for MockRepository {
+        fn set(&self, key: u64, val: User) {
+            eprintln!("added {val:?}");
+        }
+
+        fn get(&self, key: &u64) -> Option<Ref<User>> {
+            if key == &123 {
+                Ref::filter_map(self.value.borrow(), |v| v.as_ref()).ok()
+            } else {
+                None
+            }
+        }
+
+        fn remove(&self, key: &u64) -> Option<User> {
+            if key == &123 {
+                self.value.replace(None)
+            } else {
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn mock_repository() {
+        let repository = MockRepository::new();
+        let user = User {
+            id: 0,
+            email: Default::default(),
+            activated: false,
+        };
+
+        user.handle_command(&CreateUser, &repository).unwrap();
+
+        assert!(repository.get(&0).is_none());
+        assert!(repository.remove(&0).is_none());
+
+        assert_eq!(repository.get(&123).map(|u| u.id), Some(123));
+        assert_eq!(repository.get(&123).unwrap().email, "foo");
+        assert_eq!(repository.get(&123).map(|u| u.activated), Some(true));
+        assert_eq!(repository.remove(&123).map(|u| u.id), Some(123));
+        assert!(repository.remove(&123).is_none());
+        assert!(repository.get(&123).is_none());
+        assert!(repository.get(&0).is_none());
+    }
 }

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ root (i.e. `cargo run -p step_1_8`). __Consider to use [rustfmt] and [Clippy] wh
     - [x] [1.4. Clone-on-write][Step 1.4] (1 day)
     - [x] [1.5. Conversions, casting and dereferencing][Step 1.5] (1 day)
     - [x] [1.6. Static and dynamic dispatch][Step 1.6] (1 day)
-    - [ ] [1.7. `Sized` and `?Sized` types][Step 1.7] (1 day)
+    - [x] [1.7. `Sized` and `?Sized` types][Step 1.7] (1 day)
     - [ ] [1.8. Thread safety][Step 1.8] (1 day)
     - [ ] [1.9. Phantom types][Step 1.9] (1 day)
 - [ ] [2. Idioms][Step 2] (2 days, after all sub-steps)


### PR DESCRIPTION
Resolves [Step 1.7](https://github.com/Tassadaritze/rust-incubator/blob/main/1_concepts/1_7_sized)




## Task

Given the [`User` and `UserRepository` implementations from the previous task](https://github.com/Tassadaritze/rust-incubator/blob/main/1_concepts/1_6_dispatch#task), write the actual code for `CommandHandler<CreateUser>` implementation described above.

Provide tests for `CommandHandler<CreateUser>` implementation where `dyn UserRepository` is mocked with another hand-written type for testing purposes (you will need to transform the `UserRepository` type into a trait).





## Solution

Created an `InMemoryRepository` that implements `UserRepository` and is backed by a `RefCell<HashMap<u64, User>>`.

Created a `MockRepository` that implements `UserRepository` and is backed by a `RefCell<Option<User>>` containing a `User` with some preset values. Attempts to set a user won't mutate, but will log the value that was going to be set. The other methods behave as expected, just adjusted for the actual backing storage.